### PR TITLE
Fix segfault in C code to generate {error, Reason}.

### DIFF
--- a/apps/termsend/c_src/termsend.c
+++ b/apps/termsend/c_src/termsend.c
@@ -16,7 +16,7 @@ mk_atom(ErlNifEnv* env, const char* atom)
 ERL_NIF_TERM
 mk_error(ErlNifEnv* env, const char* mesg)
 {
-    return enif_make_tuple(env, mk_atom(env, "error"), mk_atom(env, mesg));
+    return enif_make_tuple2(env, mk_atom(env, "error"), mk_atom(env, mesg));
 }
 
 static ERL_NIF_TERM


### PR DESCRIPTION
If you pass an invalid value to termsend:repeat you will probably get a segfault:

Eshell V7.0.2  (abort with ^G)
1> termsend:repeat(self(), hello).
ok
2> termsend:repeat(invalid, hello).
Segmentation fault

This is because mk_error uses enif_make_tuple rather than enif_make_tuple2. Once that's fixed:

Eshell V7.0.2  (abort with ^G)
1> termsend:repeat(self(), hello).
ok
2> termsend:repeat(invalid, hello).
{error,not_a_pid}
3> 
